### PR TITLE
Enforce joint position limits on internal joint state before making trajectory

### DIFF
--- a/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
+++ b/moveit_ros/moveit_servo/include/moveit_servo/servo_calcs.h
@@ -151,12 +151,13 @@ protected:
    * Is handled differently for position vs. velocity control.
    */
   void suddenHalt(trajectory_msgs::msg::JointTrajectory& joint_trajectory) const;
+  void suddenHalt(sensor_msgs::msg::JointState& joint_state) const;
 
   /** \brief  Scale the delta theta to match joint velocity/acceleration limits */
   void enforceVelLimits(Eigen::ArrayXd& delta_theta);
 
   /** \brief Avoid overshooting joint limits */
-  bool enforcePositionLimits(trajectory_msgs::msg::JointTrajectory& joint_trajectory) const;
+  bool enforcePositionLimits(sensor_msgs::msg::JointState& joint_state) const;
 
   /** \brief Possibly calculate a velocity scaling factor, due to proximity of
    * singularity and direction of motion


### PR DESCRIPTION
### Description

This switchs the order that `composeJointTrajMessage` and `enforcePositionLimits` is called so that `enforcePositionLimits` works on a JointState and uses internal_joint_state_ which holds position and velocity information regardless of what should be published. Previously: it was operating on the JointTrajectory and had to take publishing booleans into consideration

Tested locally, including being able to back away from joint position limit. Shameless plug for [new Servo tutorial](http://moveit2_tutorials.picknik.ai/doc/realtime_servo/realtime_servo_tutorial.html#launching-a-standalone-servo-node) which includes using a keyboard as input (how I tested the joint limits)
