### PR TITLE
WIP: Add gripper controller plugin for moveit ros control interface

### DIFF
--- a/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
@@ -1,101 +1,85 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.10.2)
 project(moveit_ros_control_interface)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+find_package(ament_cmake REQUIRED)
 
-find_package(catkin REQUIRED COMPONENTS
-  actionlib
-  controller_manager_msgs
-  moveit_core
-  moveit_simple_controller_manager
-  pluginlib
-  trajectory_msgs
-)
-## System dependencies are found with CMake's conventions
-find_package(Boost REQUIRED COMPONENTS system thread)
-
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES
-    ${PROJECT_NAME}_plugin
-    ${PROJECT_NAME}_trajectory_plugin
-  CATKIN_DEPENDS
-    actionlib
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+    rclcpp_action
     controller_manager_msgs
     moveit_core
+    moveit_simple_controller_manager
+    pluginlib
     trajectory_msgs
-  DEPENDS Boost
 )
 
-include_directories(include)
-include_directories(SYSTEM ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+foreach(dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${dependency} REQUIRED)
+endforeach()
 
-add_library(${PROJECT_NAME}_plugin
+# Common cmake code applied to all moveit packages
+find_package(moveit_common REQUIRED)
+moveit_package()
+
+# Finds Boost Components
+include(ConfigExtras.cmake)
+
+add_library(${PROJECT_NAME}_plugin SHARED
   src/controller_manager_plugin.cpp
 )
 set_target_properties(${PROJECT_NAME}_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${PROJECT_NAME}_plugin
-  ${catkin_LIBRARIES} ${Boost_LIBRARIES}
+target_include_directories(${PROJECT_NAME}_plugin PRIVATE include)
+ament_target_dependencies(${PROJECT_NAME}_plugin
+    ${THIS_PACKAGE_INCLUDE_DEPENDS}
+    Boost
 )
 
-add_library(${PROJECT_NAME}_trajectory_plugin
+add_library(${PROJECT_NAME}_trajectory_plugin SHARED
   src/joint_trajectory_controller_plugin.cpp
 )
 set_target_properties(${PROJECT_NAME}_trajectory_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-target_link_libraries(${PROJECT_NAME}_trajectory_plugin
-  ${catkin_LIBRARIES} ${Boost_LIBRARIES}
+target_include_directories(${PROJECT_NAME}_trajectory_plugin PRIVATE include)
+ament_target_dependencies(${PROJECT_NAME}_trajectory_plugin
+    ${THIS_PACKAGE_INCLUDE_DEPENDS}
+    Boost
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+
+  # These don't pass yet, disable them for now
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cppcheck_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  set(ament_cmake_uncrustify_FOUND TRUE)
+
+  # Run all lint tests in package.xml except those listed above
+  ament_lint_auto_find_test_dependencies()
+endif()
 
 #############
 ## Install ##
 #############
 
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
 ## Mark executables and/or libraries for installation
 install(TARGETS ${PROJECT_NAME}_plugin ${PROJECT_NAME}_trajectory_plugin
-ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+EXPORT export_${PROJECT_NAME}
+ARCHIVE DESTINATION lib
+LIBRARY DESTINATION lib
+RUNTIME DESTINATION bin
 )
 
 ## Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
-install(FILES moveit_core_plugins.xml moveit_ros_control_interface_plugins.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  DESTINATION include
 )
 
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
+pluginlib_export_plugin_description_file(moveit_core moveit_core_plugins.xml)
+pluginlib_export_plugin_description_file(moveit_ros_control_interface moveit_ros_control_interface_plugins.xml)
 
-#############
-## Testing ##
-#############
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(
+    ${THIS_PACKAGE_INCLUDE_DEPENDS}
+    Boost
+)
 
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_canopen_master.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+ament_package(CONFIG_EXTRAS ConfigExtras.cmake)

--- a/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
@@ -43,6 +43,16 @@ ament_target_dependencies(${PROJECT_NAME}_trajectory_plugin
     Boost
 )
 
+add_library(${PROJECT_NAME}_gripper_plugin SHARED
+  src/gripper_controller_plugin.cpp
+)
+set_target_properties(${PROJECT_NAME}_gripper_plugin PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+target_include_directories(${PROJECT_NAME}_gripper_plugin PRIVATE include)
+ament_target_dependencies(${PROJECT_NAME}_gripper_plugin
+    ${THIS_PACKAGE_INCLUDE_DEPENDS}
+    Boost
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
 
@@ -61,7 +71,7 @@ endif()
 #############
 
 ## Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME}_plugin ${PROJECT_NAME}_trajectory_plugin
+install(TARGETS ${PROJECT_NAME}_plugin ${PROJECT_NAME}_trajectory_plugin ${PROJECT_NAME}_gripper_plugin
 EXPORT export_${PROJECT_NAME}
 ARCHIVE DESTINATION lib
 LIBRARY DESTINATION lib

--- a/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
+++ b/moveit_plugins/moveit_ros_control_interface/CMakeLists.txt
@@ -71,7 +71,10 @@ endif()
 #############
 
 ## Mark executables and/or libraries for installation
-install(TARGETS ${PROJECT_NAME}_plugin ${PROJECT_NAME}_trajectory_plugin ${PROJECT_NAME}_gripper_plugin
+install(TARGETS
+  ${PROJECT_NAME}_plugin
+  ${PROJECT_NAME}_trajectory_plugin
+  ${PROJECT_NAME}_gripper_plugin
 EXPORT export_${PROJECT_NAME}
 ARCHIVE DESTINATION lib
 LIBRARY DESTINATION lib

--- a/moveit_plugins/moveit_ros_control_interface/ConfigExtras.cmake
+++ b/moveit_plugins/moveit_ros_control_interface/ConfigExtras.cmake
@@ -1,0 +1,3 @@
+# Extras module needed for dependencies to find boost components
+
+find_package(Boost REQUIRED COMPONENTS system thread)

--- a/moveit_plugins/moveit_ros_control_interface/include/moveit_ros_control_interface/ControllerHandle.h
+++ b/moveit_plugins/moveit_ros_control_interface/include/moveit_ros_control_interface/ControllerHandle.h
@@ -41,7 +41,7 @@
 
 namespace moveit_ros_control_interface
 {
-MOVEIT_CLASS_FORWARD(ControllerHandleAllocator)  // Defines ControllerHandleAllocatorPtr, ConstPtr, WeakPtr... etc
+MOVEIT_CLASS_FORWARD(ControllerHandleAllocator);  // Defines ControllerHandleAllocatorPtr, ConstPtr, WeakPtr... etc
 
 /**
  * Base class for MoveItControllerHandle allocators
@@ -49,8 +49,8 @@ MOVEIT_CLASS_FORWARD(ControllerHandleAllocator)  // Defines ControllerHandleAllo
 class ControllerHandleAllocator
 {
 public:
-  virtual moveit_controller_manager::MoveItControllerHandlePtr alloc(const std::string& name,
-                                                                     const std::vector<std::string>& resources) = 0;
+  virtual moveit_controller_manager::MoveItControllerHandlePtr
+  alloc(const rclcpp::Node::SharedPtr& node, const std::string& name, const std::vector<std::string>& resources) = 0;
   virtual ~ControllerHandleAllocator()
   {
   }

--- a/moveit_plugins/moveit_ros_control_interface/moveit_core_plugins.xml
+++ b/moveit_plugins/moveit_ros_control_interface/moveit_core_plugins.xml
@@ -1,9 +1,13 @@
 <class_libraries>
-  <library path="lib/libmoveit_ros_control_interface_plugin">
-    <class type="moveit_ros_control_interface::MoveItControllerManager" base_class_type="moveit_controller_manager::MoveItControllerManager">
+  <library path="moveit_ros_control_interface_plugin">
+    <class name="moveit_ros_control_interface/MoveItControllerManager"
+           type="moveit_ros_control_interface::MoveItControllerManager"
+           base_class_type="moveit_controller_manager::MoveItControllerManager">
         <description>ros_control controller manager interface for MoveIt</description>
     </class>
-    <class type="moveit_ros_control_interface::MoveItMultiControllerManager" base_class_type="moveit_controller_manager::MoveItControllerManager">
+    <class name="moveit_ros_control_interface/MoveItMultiControllerManager"
+           type="moveit_ros_control_interface::MoveItMultiControllerManager"
+           base_class_type="moveit_controller_manager::MoveItControllerManager">
         <description>multiple ros_control controller managers interface for MoveIt</description>
     </class>
   </library>

--- a/moveit_plugins/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
+++ b/moveit_plugins/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
@@ -1,18 +1,6 @@
 <class_libraries>
-  <library path="lib/libmoveit_ros_control_interface_trajectory_plugin">
-    <class name="position_controllers/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
-        <description></description>
-    </class>
-    <class name="velocity_controllers/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
-        <description></description>
-    </class>
-    <class name="effort_controllers/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
-        <description></description>
-    </class>
-    <class name="pos_vel_controllers/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
-        <description></description>
-    </class>
-    <class name="pos_vel_acc_controllers/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
+  <library path="moveit_ros_control_interface_trajectory_plugin">
+    <class name="joint_trajectory_controller/JointTrajectoryController" type="moveit_ros_control_interface::JointTrajectoryControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
         <description></description>
     </class>
   </library>

--- a/moveit_plugins/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
+++ b/moveit_plugins/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
@@ -4,4 +4,10 @@
         <description></description>
     </class>
   </library>
+
+  <library path="moveit_ros_control_interface_gripper_plugin">
+    <class name="position_controllers/GripperActionController" type="moveit_ros_control_interface::GripperControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
+        <description></description>
+    </class>
+  </library>
 </class_libraries>

--- a/moveit_plugins/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
+++ b/moveit_plugins/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
@@ -4,9 +4,11 @@
         <description></description>
     </class>
   </library>
-
   <library path="moveit_ros_control_interface_gripper_plugin">
     <class name="position_controllers/GripperActionController" type="moveit_ros_control_interface::GripperControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
+        <description></description>
+    </class>
+    <class name="effort_controllers/GripperActionController" type="moveit_ros_control_interface::GripperControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
         <description></description>
     </class>
   </library>

--- a/moveit_plugins/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
+++ b/moveit_plugins/moveit_ros_control_interface/moveit_ros_control_interface_plugins.xml
@@ -8,6 +8,7 @@
     <class name="position_controllers/GripperActionController" type="moveit_ros_control_interface::GripperControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
         <description></description>
     </class>
+
     <class name="effort_controllers/GripperActionController" type="moveit_ros_control_interface::GripperControllerAllocator" base_class_type="moveit_ros_control_interface::ControllerHandleAllocator">
         <description></description>
     </class>

--- a/moveit_plugins/moveit_ros_control_interface/package.xml
+++ b/moveit_plugins/moveit_ros_control_interface/package.xml
@@ -11,16 +11,19 @@
 
   <license>BSD</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
-  <depend>actionlib</depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>moveit_common</build_depend>
+  <depend>rclcpp_action</depend>
   <depend>controller_manager_msgs</depend>
   <depend>moveit_core</depend>
   <depend>moveit_simple_controller_manager</depend>
   <depend version_gte="1.11.2">pluginlib</depend>
   <depend>trajectory_msgs</depend>
 
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
   <export>
-     <moveit_core plugin="${prefix}/moveit_core_plugins.xml" />
-     <moveit_ros_control_interface plugin="${prefix}/moveit_ros_control_interface_plugins.xml" />
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -144,7 +144,9 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
     auto result_future = list_controllers_service_->async_send_request(request);
     if (result_future.wait_for(std::chrono::duration<double>(SERVICE_CALL_TIMEOUT)) == std::future_status::timeout)
     {
-      RCLCPP_WARN_STREAM(LOGGER, "Failed to read controllers from " << list_controllers_service_->get_service_name());
+      RCLCPP_WARN_STREAM(LOGGER, "Failed to read controllers from " << list_controllers_service_->get_service_name()
+                                                                    << " within " << SERVICE_CALL_TIMEOUT
+                                                                    << " seconds");
       return;
     }
 
@@ -396,7 +398,10 @@ public:
       auto result_future = switch_controller_service_->async_send_request(request);
       if (result_future.wait_for(std::chrono::duration<double>(SERVICE_CALL_TIMEOUT)) == std::future_status::timeout)
       {
-        RCLCPP_ERROR_STREAM(LOGGER, "Could switch controllers at " << switch_controller_service_->get_service_name());
+        RCLCPP_ERROR_STREAM(LOGGER, "Couldn't switch controllers at " << switch_controller_service_->get_service_name()
+                                                                      << " within " << SERVICE_CALL_TIMEOUT
+                                                                      << " seconds");
+        return false;
       }
       discover(true);
       return result_future.get()->ok;

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -84,7 +84,7 @@ bool checkTimeout(const rclcpp::Clock::SharedPtr& clock, rclcpp::Time& t, double
  * @param[in] claimed_interface claimed interface as joint_name/INTERFACE_TYPE
  * @return joint_name part of the /p claimed_interface
  */
-std::string getJointName(const std::string& claimed_interface)
+std::string parseJointNameFromResource(const std::string& claimed_interface)
 {
   const auto index = claimed_interface.find('/');
   if (index == std::string::npos)
@@ -158,7 +158,9 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
         auto& claimed_interfaces = active_controllers_.insert(std::make_pair(controller.name, controller))
                                        .first->second.claimed_interfaces;  // without namespace
         std::transform(claimed_interfaces.cbegin(), claimed_interfaces.cend(), claimed_interfaces.begin(),
-                       [](const std::string& claimed_interface) { return getJointName(claimed_interface); });
+                       [](const std::string& claimed_interface) {
+                         return parseJointNameFromResource(claimed_interface);
+                       });
       }
       if (loader_.isClassAvailable(controller.type))
       {
@@ -166,7 +168,9 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
         auto controller_it = managed_controllers_.insert(std::make_pair(absname, controller)).first;  // with namespace
         auto& claimed_interfaces = controller_it->second.claimed_interfaces;
         std::transform(claimed_interfaces.cbegin(), claimed_interfaces.cend(), claimed_interfaces.begin(),
-                       [](const std::string& claimed_interface) { return getJointName(claimed_interface); });
+                       [](const std::string& claimed_interface) {
+                         return parseJointNameFromResource(claimed_interface);
+                       });
         allocate(absname, controller_it->second);
       }
     }
@@ -193,7 +197,7 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
       // Collect claimed resources across different hardware interfaces
       for (const auto& resource : controller.claimed_interfaces)
       {
-        resources.push_back(getJointName(resource));
+        resources.push_back(parseJointNameFromResource(resource));
       }
 
       moveit_controller_manager::MoveItControllerHandlePtr handle =

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -34,16 +34,17 @@
 
 /* Author: Mathias Lüdtke */
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <moveit/macros/class_forward.h>
+#include <moveit/utils/rclcpp_utils.h>
 
 #include <moveit_ros_control_interface/ControllerHandle.h>
 
 #include <moveit/controller_manager/controller_manager.h>
 
-#include <controller_manager_msgs/ListControllers.h>
-#include <controller_manager_msgs/SwitchController.h>
+#include <controller_manager_msgs/srv/list_controllers.hpp>
+#include <controller_manager_msgs/srv/switch_controller.hpp>
 
 #include <pluginlib/class_list_macros.hpp>
 #include <pluginlib/class_loader.hpp>
@@ -52,6 +53,10 @@
 
 #include <map>
 #include <memory>
+
+static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit.plugins.ros_control_interface");
+static const double CONTROLLER_INFORMATION_VALIDITY_AGE = 1.0;
+static const double SERVICE_CALL_TIMEOUT = 1.0;
 
 namespace moveit_ros_control_interface
 {
@@ -62,10 +67,10 @@ namespace moveit_ros_control_interface
  * @param[in] force force timeout
  * @return True if timeout duration was passed
  */
-bool checkTimeout(ros::Time& t, double timeout, bool force = false)
+bool checkTimeout(const rclcpp::Clock::SharedPtr& clock, rclcpp::Time& t, double timeout, bool force = false)
 {
-  ros::Time now = ros::Time::now();
-  if (force || (now - t) >= ros::Duration(timeout))
+  rclcpp::Time now = clock->now();
+  if (force || (now - t) >= rclcpp::Duration::from_seconds(timeout))
   {
     t = now;
     return true;
@@ -73,7 +78,21 @@ bool checkTimeout(ros::Time& t, double timeout, bool force = false)
   return false;
 }
 
-MOVEIT_CLASS_FORWARD(MoveItControllerManager)  // Defines MoveItControllerManagerPtr, ConstPtr, WeakPtr... etc
+/**
+ * \brief Get joint name from resource name reported by ros2_control, since claimed_interfaces return by ros2_control
+ * will have the interface name as suffix joint_name/INTERFACE_TYPE
+ * @param[in] claimed_interface claimed interface as joint_name/INTERFACE_TYPE
+ * @return joint_name part of the /p claimed_interface
+ */
+std::string getJointName(const std::string& claimed_interface)
+{
+  const auto index = claimed_interface.find('/');
+  if (index == std::string::npos)
+    return claimed_interface;
+  return claimed_interface.substr(0, index);
+}
+
+MOVEIT_CLASS_FORWARD(MoveItControllerManager);  // Defines MoveItControllerManagerPtr, ConstPtr, WeakPtr... etc
 
 /**
  * \brief moveit_controller_manager::MoveItControllerManager sub class that interfaces one ros_control
@@ -83,9 +102,9 @@ MOVEIT_CLASS_FORWARD(MoveItControllerManager)  // Defines MoveItControllerManage
  */
 class MoveItControllerManager : public moveit_controller_manager::MoveItControllerManager
 {
-  const std::string ns_;
+  std::string ns_;
   pluginlib::ClassLoader<ControllerHandleAllocator> loader_;
-  typedef std::map<std::string, controller_manager_msgs::ControllerState> ControllersMap;
+  typedef std::map<std::string, controller_manager_msgs::msg::ControllerState> ControllersMap;
   ControllersMap managed_controllers_;
   ControllersMap active_controllers_;
   typedef std::map<std::string, ControllerHandleAllocatorPtr> AllocatorsMap;
@@ -94,17 +113,20 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
   typedef std::map<std::string, moveit_controller_manager::MoveItControllerHandlePtr> HandleMap;
   HandleMap handles_;
 
-  ros::Time controllers_stamp_;
-  boost::mutex controllers_mutex_;
+  rclcpp::Time controllers_stamp_{ 0, 0, RCL_ROS_TIME };
+  std::mutex controllers_mutex_;
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Client<controller_manager_msgs::srv::ListControllers>::SharedPtr list_controllers_service_;
+  rclcpp::Client<controller_manager_msgs::srv::SwitchController>::SharedPtr switch_controller_service_;
 
   /**
    * \brief Check if given controller is active
    * @param s state of controller
    * @return true if controller is active
    */
-  static bool isActive(const controller_manager_msgs::ControllerState& s)
+  static bool isActive(const controller_manager_msgs::msg::ControllerState& s)
   {
-    return s.state == std::string("running");
+    return s.state == std::string("active");
   }
 
   /**
@@ -115,27 +137,37 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
    */
   void discover(bool force = false)
   {
-    if (!checkTimeout(controllers_stamp_, 1.0, force))
+    if (!checkTimeout(node_->get_clock(), controllers_stamp_, CONTROLLER_INFORMATION_VALIDITY_AGE, force))
       return;
 
-    controller_manager_msgs::ListControllers srv;
-    if (!ros::service::call(getAbsName("controller_manager/list_controllers"), srv))
+    auto request = std::make_shared<controller_manager_msgs::srv::ListControllers::Request>();
+    auto result_future = list_controllers_service_->async_send_request(request);
+    if (result_future.wait_for(std::chrono::duration<double>(SERVICE_CALL_TIMEOUT)) == std::future_status::timeout)
     {
-      ROS_WARN_STREAM("Failed to read controllers from " << ns_ << "controller_manager/list_controllers");
+      RCLCPP_WARN_STREAM(LOGGER, "Failed to read controllers from " << list_controllers_service_->get_service_name());
+      return;
     }
+
     managed_controllers_.clear();
     active_controllers_.clear();
-    for (const controller_manager_msgs::ControllerState& controller : srv.response.controller)
+
+    for (const controller_manager_msgs::msg::ControllerState& controller : result_future.get()->controller)
     {
       if (isActive(controller))
       {
-        active_controllers_.insert(std::make_pair(controller.name, controller));  // without namespace
+        auto& claimed_interfaces = active_controllers_.insert(std::make_pair(controller.name, controller))
+                                       .first->second.claimed_interfaces;  // without namespace
+        std::transform(claimed_interfaces.cbegin(), claimed_interfaces.cend(), claimed_interfaces.begin(),
+                       [](const std::string& claimed_interface) { return getJointName(claimed_interface); });
       }
       if (loader_.isClassAvailable(controller.type))
       {
         std::string absname = getAbsName(controller.name);
-        managed_controllers_.insert(std::make_pair(absname, controller));  // with namespace
-        allocate(absname, controller);
+        auto controller_it = managed_controllers_.insert(std::make_pair(absname, controller)).first;  // with namespace
+        auto& claimed_interfaces = controller_it->second.claimed_interfaces;
+        std::transform(claimed_interfaces.cbegin(), claimed_interfaces.cend(), claimed_interfaces.begin(),
+                       [](const std::string& claimed_interface) { return getJointName(claimed_interface); });
+        allocate(absname, controller_it->second);
       }
     }
   }
@@ -146,7 +178,7 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
    * @param name fully qualified name of the controller
    * @param controller controller information
    */
-  void allocate(const std::string& name, const controller_manager_msgs::ControllerState& controller)
+  void allocate(const std::string& name, const controller_manager_msgs::msg::ControllerState& controller)
   {
     if (handles_.find(name) == handles_.end())
     {
@@ -159,16 +191,13 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
 
       std::vector<std::string> resources;
       // Collect claimed resources across different hardware interfaces
-      for (const controller_manager_msgs::HardwareInterfaceResources& claimed_resource : controller.claimed_resources)
+      for (const auto& resource : controller.claimed_interfaces)
       {
-        for (const std::string& resource : claimed_resource.resources)
-        {
-          resources.push_back(resource);
-        }
+        resources.push_back(getJointName(resource));
       }
 
       moveit_controller_manager::MoveItControllerHandlePtr handle =
-          alloc_it->second->alloc(name, resources);  // allocate handle
+          alloc_it->second->alloc(node_, name, resources);  // allocate handle
       if (handle)
         handles_.insert(std::make_pair(name, handle));
     }
@@ -181,7 +210,7 @@ class MoveItControllerManager : public moveit_controller_manager::MoveItControll
    */
   std::string getAbsName(const std::string& name)
   {
-    return ros::names::append(ns_, name);
+    return rclcpp::names::append(ns_, name);
   }
 
 public:
@@ -189,10 +218,9 @@ public:
    * \brief The default constructor. Reads the namespace from ~ros_control_namespace param and defaults to /
    */
   MoveItControllerManager()
-    : ns_(ros::NodeHandle("~").param("ros_control_namespace", std::string("/")))
-    , loader_("moveit_ros_control_interface", "moveit_ros_control_interface::ControllerHandleAllocator")
+    : loader_("moveit_ros_control_interface", "moveit_ros_control_interface::ControllerHandleAllocator")
   {
-    ROS_INFO_STREAM("Started moveit_ros_control_interface::MoveItControllerManager for namespace " << ns_);
+    RCLCPP_INFO_STREAM(LOGGER, "Started moveit_ros_control_interface::MoveItControllerManager for namespace " << ns_);
   }
 
   /**
@@ -204,6 +232,19 @@ public:
   {
   }
 
+  void initialize(const rclcpp::Node::SharedPtr& node) override
+  {
+    node_ = node;
+    if (!ns_.empty())
+    {
+      if (!node_->has_parameter("ros_control_namespace"))
+        ns_ = node_->declare_parameter<std::string>("ros_control_namespace", "/");
+    }
+    list_controllers_service_ = node_->create_client<controller_manager_msgs::srv::ListControllers>(
+        getAbsName("controller_manager/list_controllers"));
+    switch_controller_service_ = node_->create_client<controller_manager_msgs::srv::SwitchController>(
+        getAbsName("controller_manager/switch_controller"));
+  }
   /**
    * \brief Find and return the pre-allocated handle for the given controller.
    * @param name
@@ -211,7 +252,7 @@ public:
    */
   moveit_controller_manager::MoveItControllerHandlePtr getControllerHandle(const std::string& name) override
   {
-    boost::mutex::scoped_lock lock(controllers_mutex_);
+    std::unique_lock<std::mutex> lock(controllers_mutex_);
     HandleMap::iterator it = handles_.find(name);
     if (it != handles_.end())
     {  // controller is is manager by this interface
@@ -226,10 +267,10 @@ public:
    */
   void getControllersList(std::vector<std::string>& names) override
   {
-    boost::mutex::scoped_lock lock(controllers_mutex_);
+    std::unique_lock<std::mutex> lock(controllers_mutex_);
     discover();
 
-    for (std::pair<const std::string, controller_manager_msgs::ControllerState>& managed_controller :
+    for (std::pair<const std::string, controller_manager_msgs::msg::ControllerState>& managed_controller :
          managed_controllers_)
     {
       names.push_back(managed_controller.first);
@@ -242,10 +283,10 @@ public:
    */
   void getActiveControllers(std::vector<std::string>& names) override
   {
-    boost::mutex::scoped_lock lock(controllers_mutex_);
+    std::unique_lock<std::mutex> lock(controllers_mutex_);
     discover();
 
-    for (std::pair<const std::string, controller_manager_msgs::ControllerState>& managed_controller :
+    for (std::pair<const std::string, controller_manager_msgs::msg::ControllerState>& managed_controller :
          managed_controllers_)
     {
       if (isActive(managed_controller.second))
@@ -260,14 +301,13 @@ public:
    */
   void getControllerJoints(const std::string& name, std::vector<std::string>& joints) override
   {
-    boost::mutex::scoped_lock lock(controllers_mutex_);
+    std::unique_lock<std::mutex> lock(controllers_mutex_);
     ControllersMap::iterator it = managed_controllers_.find(name);
     if (it != managed_controllers_.end())
     {
-      for (controller_manager_msgs::HardwareInterfaceResources& claimed_resource : it->second.claimed_resources)
+      for (const auto& claimed_resource : it->second.claimed_interfaces)
       {
-        std::vector<std::string>& resources = claimed_resource.resources;
-        joints.insert(joints.end(), resources.begin(), resources.end());
+        joints.push_back(claimed_resource);
       }
     }
   }
@@ -279,7 +319,7 @@ public:
    */
   ControllerState getControllerState(const std::string& name) override
   {
-    boost::mutex::scoped_lock lock(controllers_mutex_);
+    std::unique_lock<std::mutex> lock(controllers_mutex_);
     discover();
 
     ControllerState c;
@@ -300,7 +340,7 @@ public:
    */
   bool switchControllers(const std::vector<std::string>& activate, const std::vector<std::string>& deactivate) override
   {
-    boost::mutex::scoped_lock lock(controllers_mutex_);
+    std::unique_lock<std::mutex> lock(controllers_mutex_);
     discover(true);
 
     typedef boost::bimap<std::string, std::string> resources_bimap;
@@ -308,27 +348,22 @@ public:
     resources_bimap claimed_resources;
 
     // fill bimap with active controllers and their resources
-    for (std::pair<const std::string, controller_manager_msgs::ControllerState>& active_controller : active_controllers_)
+    for (std::pair<const std::string, controller_manager_msgs::msg::ControllerState>& active_controller :
+         active_controllers_)
     {
-      for (std::vector<controller_manager_msgs::HardwareInterfaceResources>::iterator hir =
-               active_controller.second.claimed_resources.begin();
-           hir != active_controller.second.claimed_resources.end(); ++hir)
+      for (const auto& resource : active_controller.second.claimed_interfaces)
       {
-        for (std::string& resource : hir->resources)
-        {
-          claimed_resources.insert(resources_bimap::value_type(active_controller.second.name, resource));
-        }
+        claimed_resources.insert(resources_bimap::value_type(active_controller.second.name, resource));
       }
     }
 
-    controller_manager_msgs::SwitchController srv;
-
+    auto request = std::make_shared<controller_manager_msgs::srv::SwitchController::Request>();
     for (const std::string& it : deactivate)
     {
       ControllersMap::iterator c = managed_controllers_.find(it);
       if (c != managed_controllers_.end())
       {  // controller belongs to this manager
-        srv.request.stop_controllers.push_back(c->second.name);
+        request->stop_controllers.push_back(c->second.name);
         claimed_resources.right.erase(c->second.name);  // remove resources
       }
     }
@@ -338,31 +373,29 @@ public:
       ControllersMap::iterator c = managed_controllers_.find(it);
       if (c != managed_controllers_.end())
       {  // controller belongs to this manager
-        srv.request.start_controllers.push_back(c->second.name);
-        for (controller_manager_msgs::HardwareInterfaceResources& claimed_resource : c->second.claimed_resources)
+        request->start_controllers.push_back(c->second.name);
+        for (const auto& claimed_resource : c->second.claimed_interfaces)
         {
-          for (const std::string& resource : claimed_resource.resources)
-          {  // for all claimed resource
-            resources_bimap::right_const_iterator res = claimed_resources.right.find(resource);
-            if (res != claimed_resources.right.end())
-            {                                                       // resource is claimed
-              srv.request.stop_controllers.push_back(res->second);  // add claiming controller to stop list
-              claimed_resources.left.erase(res->second);            // remove claimed resources
-            }
+          resources_bimap::right_const_iterator res = claimed_resources.right.find(claimed_resource);
+          if (res != claimed_resources.right.end())
+          {                                                    // resource is claimed
+            request->stop_controllers.push_back(res->second);  // add claiming controller to stop list
+            claimed_resources.left.erase(res->second);         // remove claimed resources
           }
         }
       }
     }
-    srv.request.strictness = srv.request.STRICT;
+    request->strictness = controller_manager_msgs::srv::SwitchController::Request::STRICT;
 
-    if (!srv.request.start_controllers.empty() || srv.request.stop_controllers.empty())
+    if (!request->start_controllers.empty() || request->stop_controllers.empty())
     {  // something to switch?
-      if (!ros::service::call(getAbsName("controller_manager/switch_controller"), srv))
+      auto result_future = switch_controller_service_->async_send_request(request);
+      if (result_future.wait_for(std::chrono::duration<double>(SERVICE_CALL_TIMEOUT)) == std::future_status::timeout)
       {
-        ROS_ERROR_STREAM("Could switch controllers at " << ns_);
+        RCLCPP_ERROR_STREAM(LOGGER, "Could switch controllers at " << switch_controller_service_->get_service_name());
       }
       discover(true);
-      return srv.response.ok;
+      return result_future.get()->ok;
     }
     return true;
   }
@@ -375,41 +408,39 @@ class MoveItMultiControllerManager : public moveit_controller_manager::MoveItCon
 {
   typedef std::map<std::string, moveit_ros_control_interface::MoveItControllerManagerPtr> ControllerManagersMap;
   ControllerManagersMap controller_managers_;
-  ros::Time controller_managers_stamp_;
-  boost::mutex controller_managers_mutex_;
+  rclcpp::Time controller_managers_stamp_{ 0, 0, RCL_ROS_TIME };
+  std::mutex controller_managers_mutex_;
 
+  rclcpp::Node::SharedPtr node_;
+
+  void initialize(const rclcpp::Node::SharedPtr& node) override
+  {
+    node_ = node;
+  }
   /**
    * \brief  Poll ROS master for services and filters all controller_manager/list_controllers instances
    * Throttled down to 1 Hz, controller_managers_mutex_ must be locked externally
    */
   void discover()
   {
-    if (!checkTimeout(controller_managers_stamp_, 1.0))
+    if (!checkTimeout(node_->get_clock(), controller_managers_stamp_, CONTROLLER_INFORMATION_VALIDITY_AGE))
       return;
 
-    XmlRpc::XmlRpcValue args, result, system_state;
-    args[0] = ros::this_node::getName();
+    const std::map<std::string, std::vector<std::string>> services = node_->get_service_names_and_types();
 
-    if (!ros::master::execute("getSystemState", args, result, system_state, true))
+    for (const auto& service : services)
     {
-      return;
-    }
-
-    // refer to http://wiki.ros.org/ROS/Master_API#Name_service_and_system_state
-    XmlRpc::XmlRpcValue services = system_state[2];
-
-    for (int i = 0; i < services.size(); ++i)  // NOLINT(modernize-loop-convert)
-    {
-      std::string service = services[i][0];
-      std::size_t found = service.find("controller_manager/list_controllers");
+      const auto& service_name = service.first;
+      std::size_t found = service_name.find("controller_manager/list_controllers");
       if (found != std::string::npos)
       {
-        std::string ns = service.substr(0, found);
+        std::string ns = service_name.substr(0, found);
         if (controller_managers_.find(ns) == controller_managers_.end())
         {  // create MoveItControllerManager if it does not exists
-          ROS_INFO_STREAM("Adding controller_manager interface for node at namespace " << ns);
-          controller_managers_.insert(
-              std::make_pair(ns, std::make_shared<moveit_ros_control_interface::MoveItControllerManager>(ns)));
+          RCLCPP_INFO_STREAM(LOGGER, "Adding controller_manager interface for node at namespace " << ns);
+          auto controller_manager = std::make_shared<moveit_ros_control_interface::MoveItControllerManager>(ns);
+          controller_manager->initialize(node_);
+          controller_managers_.insert(std::make_pair(ns, controller_manager));
         }
       }
     }
@@ -436,7 +467,7 @@ public:
    */
   moveit_controller_manager::MoveItControllerHandlePtr getControllerHandle(const std::string& name) override
   {
-    boost::mutex::scoped_lock lock(controller_managers_mutex_);
+    std::unique_lock<std::mutex> lock(controller_managers_mutex_);
 
     std::string ns = getNamespace(name);
     ControllerManagersMap::iterator it = controller_managers_.find(ns);
@@ -453,7 +484,7 @@ public:
    */
   void getControllersList(std::vector<std::string>& names) override
   {
-    boost::mutex::scoped_lock lock(controller_managers_mutex_);
+    std::unique_lock<std::mutex> lock(controller_managers_mutex_);
     discover();
 
     for (std::pair<const std::string, moveit_ros_control_interface::MoveItControllerManagerPtr>& controller_manager :
@@ -469,7 +500,7 @@ public:
    */
   void getActiveControllers(std::vector<std::string>& names) override
   {
-    boost::mutex::scoped_lock lock(controller_managers_mutex_);
+    std::unique_lock<std::mutex> lock(controller_managers_mutex_);
     discover();
 
     for (std::pair<const std::string, moveit_ros_control_interface::MoveItControllerManagerPtr>& controller_manager :
@@ -486,7 +517,7 @@ public:
    */
   void getControllerJoints(const std::string& name, std::vector<std::string>& joints) override
   {
-    boost::mutex::scoped_lock lock(controller_managers_mutex_);
+    std::unique_lock<std::mutex> lock(controller_managers_mutex_);
 
     std::string ns = getNamespace(name);
     ControllerManagersMap::iterator it = controller_managers_.find(ns);
@@ -503,7 +534,7 @@ public:
    */
   ControllerState getControllerState(const std::string& name) override
   {
-    boost::mutex::scoped_lock lock(controller_managers_mutex_);
+    std::unique_lock<std::mutex> lock(controller_managers_mutex_);
 
     std::string ns = getNamespace(name);
     ControllerManagersMap::iterator it = controller_managers_.find(ns);
@@ -522,7 +553,7 @@ public:
    */
   bool switchControllers(const std::vector<std::string>& activate, const std::vector<std::string>& deactivate) override
   {
-    boost::mutex::scoped_lock lock(controller_managers_mutex_);
+    std::unique_lock<std::mutex> lock(controller_managers_mutex_);
 
     for (std::pair<const std::string, moveit_ros_control_interface::MoveItControllerManagerPtr>& controller_manager :
          controller_managers_)

--- a/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/controller_manager_plugin.cpp
@@ -393,7 +393,7 @@ public:
     }
     request->strictness = controller_manager_msgs::srv::SwitchController::Request::STRICT;
 
-    if (!request->start_controllers.empty() || request->stop_controllers.empty())
+    if (!request->start_controllers.empty() || !request->stop_controllers.empty())
     {  // something to switch?
       auto result_future = switch_controller_service_->async_send_request(request);
       if (result_future.wait_for(std::chrono::duration<double>(SERVICE_CALL_TIMEOUT)) == std::future_status::timeout)

--- a/moveit_plugins/moveit_ros_control_interface/src/gripper_controller_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/gripper_controller_plugin.cpp
@@ -52,8 +52,7 @@ public:
                                                              const std::string& name,
                                                              const std::vector<std::string>& /* resources */) override
   {
-    return std::make_shared<moveit_simple_controller_manager::GripperControllerHandle>(
-        node, name, "gripper_cmd");
+    return std::make_shared<moveit_simple_controller_manager::GripperControllerHandle>(node, name, "gripper_cmd");
   }
 };
 

--- a/moveit_plugins/moveit_ros_control_interface/src/gripper_controller_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/gripper_controller_plugin.cpp
@@ -1,0 +1,63 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, PickNik Inc.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Fraunhofer IPA nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Joseph Schornak */
+
+#include <rclcpp/rclcpp.hpp>
+#include <moveit_ros_control_interface/ControllerHandle.h>
+#include <pluginlib/class_list_macros.hpp>
+#include <moveit_simple_controller_manager/gripper_controller_handle.h>
+#include <memory>
+
+namespace moveit_ros_control_interface
+{
+/**
+ * \brief Simple allocator for moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle instances.
+ */
+class GripperControllerAllocator : public ControllerHandleAllocator
+{
+public:
+  moveit_controller_manager::MoveItControllerHandlePtr alloc(const rclcpp::Node::SharedPtr& node,
+                                                             const std::string& name,
+                                                             const std::vector<std::string>& /* resources */) override
+  {
+    return std::make_shared<moveit_simple_controller_manager::GripperControllerHandle>(
+        node, name, "gripper_cmd");
+  }
+};
+
+}  // namespace moveit_ros_control_interface
+
+PLUGINLIB_EXPORT_CLASS(moveit_ros_control_interface::GripperControllerAllocator,
+                       moveit_ros_control_interface::ControllerHandleAllocator);

--- a/moveit_plugins/moveit_ros_control_interface/src/gripper_controller_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/gripper_controller_plugin.cpp
@@ -14,7 +14,7 @@
  *     copyright notice, this list of conditions and the following
  *     disclaimer in the documentation and/or other materials provided
  *     with the distribution.
- *   * Neither the name of Fraunhofer IPA nor the names of its
+ *   * Neither the name of PickNik Inc. nor the names of its
  *     contributors may be used to endorse or promote products derived
  *     from this software without specific prior written permission.
  *
@@ -43,7 +43,7 @@
 namespace moveit_ros_control_interface
 {
 /**
- * \brief Simple allocator for moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle instances.
+ * \brief Simple allocator for moveit_simple_controller_manager::GripperControllerHandle instances.
  */
 class GripperControllerAllocator : public ControllerHandleAllocator
 {

--- a/moveit_plugins/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
+++ b/moveit_plugins/moveit_ros_control_interface/src/joint_trajectory_controller_plugin.cpp
@@ -34,7 +34,7 @@
 
 /* Author: Mathias Lüdtke */
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 #include <moveit_ros_control_interface/ControllerHandle.h>
 #include <pluginlib/class_list_macros.hpp>
 #include <moveit_simple_controller_manager/follow_joint_trajectory_controller_handle.h>
@@ -48,11 +48,12 @@ namespace moveit_ros_control_interface
 class JointTrajectoryControllerAllocator : public ControllerHandleAllocator
 {
 public:
-  moveit_controller_manager::MoveItControllerHandlePtr alloc(const std::string& name,
+  moveit_controller_manager::MoveItControllerHandlePtr alloc(const rclcpp::Node::SharedPtr& node,
+                                                             const std::string& name,
                                                              const std::vector<std::string>& /* resources */) override
   {
     return std::make_shared<moveit_simple_controller_manager::FollowJointTrajectoryControllerHandle>(
-        name, "follow_joint_trajectory");
+        node, name, "follow_joint_trajectory");
   }
 };
 

--- a/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
+++ b/moveit_ros/planning/trajectory_execution_manager/include/moveit/trajectory_execution_manager/trajectory_execution_manager.h
@@ -251,14 +251,11 @@ public:
 private:
   struct ControllerInformation
   {
-    ControllerInformation() : last_update_(0, 0, RCL_ROS_TIME)
-    {
-    }
     std::string name_;
     std::set<std::string> joints_;
     std::set<std::string> overlapping_controllers_;
     moveit_controller_manager::MoveItControllerManager::ControllerState state_;
-    rclcpp::Time last_update_;
+    rclcpp::Time last_update_{ 0, 0, RCL_ROS_TIME };
 
     bool operator<(ControllerInformation& other) const
     {

--- a/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
+++ b/moveit_ros/planning/trajectory_execution_manager/src/trajectory_execution_manager.cpp
@@ -45,7 +45,7 @@ static const rclcpp::Logger LOGGER = rclcpp::get_logger("moveit_ros.trajectory_e
 
 const std::string TrajectoryExecutionManager::EXECUTION_EVENT_TOPIC = "trajectory_execution_event";
 
-static const rclcpp::Duration DEFAULT_CONTROLLER_INFORMATION_VALIDITY_AGE(1.0);
+static const rclcpp::Duration DEFAULT_CONTROLLER_INFORMATION_VALIDITY_AGE = rclcpp::Duration::from_seconds(1.0);
 static const double DEFAULT_CONTROLLER_GOAL_DURATION_MARGIN = 0.5;  // allow 0.5s more than the expected execution time
                                                                     // before triggering a trajectory cancel (applied
                                                                     // after scaling)
@@ -1071,6 +1071,8 @@ bool TrajectoryExecutionManager::configure(TrajectoryExecutionContext& context,
     // empty trajectories don't need to configure anything
     return true;
   }
+
+  reloadControllerInformation();
   std::set<std::string> actuated_joints;
 
   auto is_actuated = [this](const std::string& joint_name) -> bool {
@@ -1765,11 +1767,11 @@ bool TrajectoryExecutionManager::ensureActiveControllers(const std::vector<std::
         for (const std::string& controller_to_activate : controllers_to_activate)
         {
           ControllerInformation& ci = known_controllers_[controller_to_activate];
-          ci.last_update_ = rclcpp::Time();
+          ci.last_update_ = rclcpp::Time(0, 0, RCL_ROS_TIME);
         }
         // reset the state update cache
         for (const std::string& controller_to_activate : controllers_to_deactivate)
-          known_controllers_[controller_to_activate].last_update_ = rclcpp::Time();
+          known_controllers_[controller_to_activate].last_update_ = rclcpp::Time(0, 0, RCL_ROS_TIME);
         return controller_manager_->switchControllers(controllers_to_activate, controllers_to_deactivate);
       }
       else


### PR DESCRIPTION
### Description

Add a ControllerAllocator for `moveit_simple_controller_manager::GripperControllerHandle`. I think this is needed to execute trajectories through the moveit_ros_control_interface for groups controlled by a gripper command controller.

### Checklist
- [ ] **Required by CI**: Code is auto formatted using [clang-format](http://moveit.ros.org/documentation/contributing/code)
- [ ] Extend the tutorials / documentation [reference](http://moveit.ros.org/documentation/contributing/)
- [ ] Document API changes relevant to the user in the MIGRATION.md notes
- [ ] Create tests, which fail without this PR [reference](https://ros-planning.github.io/moveit_tutorials/)
- [ ] Include a screenshot if changing a GUI
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/ros-planning/moveit/pulls) to support the maintainers

[//]: # "You can expect a response from a maintainer within 7 days. If you haven't heard anything by then, feel free to ping the thread. Thank you!"
